### PR TITLE
add HTTP Response class, parse index.html instead of hardcoded string

### DIFF
--- a/HTTPResponse.cpp
+++ b/HTTPResponse.cpp
@@ -1,0 +1,32 @@
+#include "HTTPResponse.hpp"
+
+#include <sstream>
+
+//// Constructors and Operator overloads
+
+HTTPResponse::HTTPResponse() {}
+
+HTTPResponse::~HTTPResponse() {}
+
+HTTPResponse::HTTPResponse(const HTTPResponse& obj)
+    : header_(obj.header_), body_(obj.body_) {}
+
+HTTPResponse& HTTPResponse::operator=(const HTTPResponse& obj) {
+  if (this != &obj) {
+    *this = obj;
+  }
+  this->header_ = obj.header_;
+  this->body_ = obj.body_;
+  return *this;
+}
+
+HTTPResponse::HTTPResponse(std::string header, std::string body)
+    : header_(header), body_(body) {}
+
+//// Public Member Functions
+
+std::string HTTPResponse::toString() const {
+  std::ostringstream oss;
+  oss << this->header_ << "\r\n\r\n" << this->body_;
+  return oss.str();
+}

--- a/HTTPResponse.hpp
+++ b/HTTPResponse.hpp
@@ -1,0 +1,23 @@
+#ifndef HTTPRESPONSE_HPP_
+#define HTTPRESPONSE_HPP_
+
+#include <string>
+
+class HTTPResponse {
+ public:
+  //// Constructors and Operator overloads
+  HTTPResponse();
+  ~HTTPResponse();
+  HTTPResponse(const HTTPResponse& obj);
+  HTTPResponse& operator=(const HTTPResponse& obj);
+  HTTPResponse(std::string header, std::string body);
+
+  //// Member Functions
+  std::string toString() const;
+
+ private:
+  std::string header_;
+  std::string body_;
+};
+
+#endif  // HTTPRESPONSE_HPP_

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 NAME =	webserv
 CXX =	c++
-CXXFLAGS =	-std=c++98 -Wall -Wextra -Werror
+CXXFLAGS =	-std=c++98 -Wall -Wextra -Werror -Wconversion
 
 GREEN =	\033[0;32m
 CYAN =	\033[0;36m
 RED =	\033[0;31m
 WHITE =	\033[0;0m
 
-SRC =	main.cpp TcpServer.cpp
+SRC =	main.cpp TcpServer.cpp HTTPResponse.cpp
 OBJ =	$(SRC:.cpp=.o)
 
 all:	$(NAME)

--- a/index.html
+++ b/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>VIMServe</title>
+    <style>
+      body {
+        color="red";
+      }
+    </style>
+  </head>
+  <body>
+    <h1> Hello Parent </h1>
+    <p> Hello from your Server :)</p>
+  </body>
+</html>


### PR DESCRIPTION
- added a basic HTTP Response class with header string and body string attribute
- HTTP Response class can be made a std::string by calling .toStr()
- Added functionality to read from index.html and create a HTTP Response with it that is then send on request