### PR TITLE
Parse incoming requests into HTTPRequest Objects

### DIFF
--- a/HTTPRequest.cpp
+++ b/HTTPRequest.cpp
@@ -39,19 +39,19 @@ HTTPRequest::method HTTPRequest::parseMethodToken(std::string& token) {
   std::remove(token.begin(), token.end(), '\r');
   if (token.compare("OPTIONS") == 0) {
     res = OPTIONS;
-  } else if (token.compare("GET") == 0 ) {
+  } else if (token.compare("GET") == 0) {
     res = GET;
-  } else if (token.compare("HEAD") == 0 ) {
+  } else if (token.compare("HEAD") == 0) {
     res = HEAD;
-  } else if (token.compare("POST") == 0 ) {
+  } else if (token.compare("POST") == 0) {
     res = POST;
-  } else if (token.compare("PUT") == 0 ) {
+  } else if (token.compare("PUT") == 0) {
     res = PUT;
-  } else if (token.compare("DELETE") == 0 ) {
+  } else if (token.compare("DELETE") == 0) {
     res = DELETE;
-  } else if (token.compare("TRACE") == 0 ) {
+  } else if (token.compare("TRACE") == 0) {
     res = TRACE;
-  } else if (token.compare("CONNECT") == 0 ) {
+  } else if (token.compare("CONNECT") == 0) {
     res = CONNECT;
   } else {
     res = UNKNOWN;

--- a/HTTPRequest.cpp
+++ b/HTTPRequest.cpp
@@ -1,0 +1,20 @@
+#include "HTTPRequest.hpp"
+
+//// Constuctors and Opearator overloads
+
+HTTPRequest::HTTPRequest() {}
+
+HTTPRequest::~HTTPRequest() {}
+
+HTTPRequest::HTTPRequest(const HTTPRequest& obj) {
+  *this = obj;
+}
+
+HTTPRequest& HTTPRequest::operator=(const HTTPRequest& obj) {
+  if (this != &obj) {
+    *this = obj;
+  }
+  return *this;
+}
+
+//// Public Member Functions

--- a/HTTPRequest.cpp
+++ b/HTTPRequest.cpp
@@ -1,14 +1,14 @@
 #include "HTTPRequest.hpp"
 
+#include <iostream>
+
 //// Constuctors and Opearator overloads
 
 HTTPRequest::HTTPRequest() {}
 
 HTTPRequest::~HTTPRequest() {}
 
-HTTPRequest::HTTPRequest(const HTTPRequest& obj) {
-  *this = obj;
-}
+HTTPRequest::HTTPRequest(const HTTPRequest& obj) { *this = obj; }
 
 HTTPRequest& HTTPRequest::operator=(const HTTPRequest& obj) {
   if (this != &obj) {
@@ -18,3 +18,15 @@ HTTPRequest& HTTPRequest::operator=(const HTTPRequest& obj) {
 }
 
 //// Public Member Functions
+
+HTTPRequest::HTTPRequest(std::string& input) {
+  std::string header(input.begin(),
+                     input.begin() + static_cast<long>(input.find("\r\n\r\n")));
+  std::string body(
+      input.begin() + static_cast<long>(input.find("\r\n\r\n")) + 1,
+      input.end());
+  std::cout << "HEADER" << std::endl;
+  std::cout << header << std::endl;
+  std::cout << "BODY" << std::endl;
+  std::cout << body << std::endl;
+}

--- a/HTTPRequest.cpp
+++ b/HTTPRequest.cpp
@@ -18,8 +18,6 @@ HTTPRequest& HTTPRequest::operator=(const HTTPRequest& obj) {
   return *this;
 }
 
-//// Public Member Functions
-
 HTTPRequest::HTTPRequest(std::string& input) {
   std::size_t header_end = input.find("\r\n\r\n");
   std::string header(input.begin(), input.begin() + header_end);
@@ -34,10 +32,26 @@ HTTPRequest::HTTPRequest(std::string& input) {
   while (std::getline(header_iss, line)) {
     std::vector<std::string> temp = this->splitLine(line, ": ");
     this->header_.insert(
-        std::pair<std::string, std::string>(temp.at(0), temp.at(1)));
+        std::pair<std::string, std::string>(temp.at(0), temp.at(2)));
   }
   this->body_ = body;
 }
+
+//// Accessors
+
+std::map<std::string, std::string> HTTPRequest::getHeader() const {
+  return this->header_;
+}
+
+std::string HTTPRequest::getBody() const { return this->body_; }
+
+HTTPRequest::method HTTPRequest::getMethod() const {
+  return this->request_method_;
+}
+
+std::string HTTPRequest::getURI() const { return this->URI_; }
+
+std::string HTTPRequest::getProtocol() const { return this->protocol_version_; }
 
 //// Private Member Functions
 
@@ -79,4 +93,23 @@ std::vector<std::string> HTTPRequest::splitLine(
     res.push_back(line.substr(current, next - current));
   } while (next != std::vector<std::string>::value_type::npos);
   return res;
+}
+
+std::ostream& operator<<(std::ostream& os, HTTPRequest& obj) {
+  std::string methods[9] = {"UNKNOWN", "OPTIONS", "GET",   "HEAD",   "POST",
+                            "PUT",     "DELETE",  "TRACE", "CONNECT"};
+  os << "--- Header: ---" << std::endl;
+  os << "Method: " << methods[obj.getMethod()] << std::endl;
+  os << "URI: " << obj.getURI() << std::endl;
+  os << "Protocol: " << obj.getProtocol() << std::endl;
+  os << "--- Additional Header Fields: ---" << std::endl;
+  std::map<std::string, std::string> header_fields = obj.getHeader();
+  for (std::map<std::string, std::string>::const_iterator it =
+           header_fields.begin();
+       it != header_fields.end(); ++it) {
+    os << it->first << ": " << it->second << std::endl;
+  }
+  os << "--- Body: ---" << std::endl;
+  os << obj.getBody() << std::endl;
+  return os;
 }

--- a/HTTPRequest.cpp
+++ b/HTTPRequest.cpp
@@ -1,6 +1,7 @@
 #include "HTTPRequest.hpp"
 
 #include <iostream>
+#include <sstream>
 
 //// Constuctors and Opearator overloads
 
@@ -27,6 +28,37 @@ HTTPRequest::HTTPRequest(std::string& input) {
       input.end());
   std::cout << "HEADER" << std::endl;
   std::cout << header << std::endl;
+  std::istringstream iss(header);
+  std::string line;
+  while (std::getline(iss, line)) {
+    this->request_method_ = parseMethodToken(line.substr(0, line.find(' ')));
+  }
   std::cout << "BODY" << std::endl;
   std::cout << body << std::endl;
+}
+
+//// Private Member Functions
+
+HTTPRequest::method HTTPRequest::parseMethodToken(std::string token) {
+  HTTPRequest::method res;
+  if (token.compare("OPTIONS") == 0) {
+    res = OPTIONS;
+  } else if (token.compare("GET") == 0 ) {
+    res = GET;
+  } else if (token.compare("HEAD") == 0 ) {
+    res = HEAD;
+  } else if (token.compare("POST") == 0 ) {
+    res = POST;
+  } else if (token.compare("PUT") == 0 ) {
+    res = PUT;
+  } else if (token.compare("DELETE") == 0 ) {
+    res = DELETE;
+  } else if (token.compare("TRACE") == 0 ) {
+    res = TRACE;
+  } else if (token.compare("CONNECT") == 0 ) {
+    res = CONNECT;
+  } else {
+    throw std::runtime_error("Error: unknown request method");
+  }
+  return res;
 }

--- a/HTTPRequest.hpp
+++ b/HTTPRequest.hpp
@@ -33,7 +33,7 @@ class HTTPRequest {
   std::string protocol_version_;
   method parseMethodToken(std::string& token);
   std::vector<std::string> splitLine(
-      std::string line, std::vector<std::string>::value_type::value_type delim);
+      std::string line, std::vector<std::string>::value_type delim);
 };
 
 #endif  // HTTPREQUEST_HPP_

--- a/HTTPRequest.hpp
+++ b/HTTPRequest.hpp
@@ -21,9 +21,10 @@ class HTTPRequest {
  private:
   std::map<std::string, std::string> header_;
   std::string body_;
-  // method request_method_;
+  method request_method_;
   // std::string URI_;
   // version protocol_version_;
+  method parseMethodToken(std::string token);
 };
 
 #endif  // HTTPREQUEST_HPP_

--- a/HTTPRequest.hpp
+++ b/HTTPRequest.hpp
@@ -1,0 +1,19 @@
+#ifndef HTTPREQUEST_HPP_
+#define HTTPREQUEST_HPP_
+
+#include <string>
+#include <map>
+
+class HTTPRequest {
+ public:
+  HTTPRequest();
+  ~HTTPRequest();
+  HTTPRequest(const HTTPRequest& obj);
+  HTTPRequest& operator=(const HTTPRequest& obj);
+
+ private:
+  std::map<std::string, std::string> header_;
+  std::string body_;
+};
+
+#endif  // HTTPREQUEST_HPP_

--- a/HTTPRequest.hpp
+++ b/HTTPRequest.hpp
@@ -1,12 +1,14 @@
 #ifndef HTTPREQUEST_HPP_
 #define HTTPREQUEST_HPP_
 
+#include <iostream>
 #include <map>
 #include <string>
 #include <vector>
 
 class HTTPRequest {
  public:
+  //// Constructors
   HTTPRequest();
   ~HTTPRequest();
   HTTPRequest(const HTTPRequest& obj);
@@ -25,6 +27,13 @@ class HTTPRequest {
     CONNECT
   } method;
 
+  //// Accessors
+  std::map<std::string, std::string> getHeader() const;
+  std::string getBody() const;
+  HTTPRequest::method getMethod() const;
+  std::string getURI() const;
+  std::string getProtocol() const;
+
  private:
   std::map<std::string, std::string> header_;
   std::string body_;
@@ -35,5 +44,7 @@ class HTTPRequest {
   std::vector<std::string> splitLine(
       std::string line, std::vector<std::string>::value_type delim);
 };
+
+std::ostream& operator<<(std::ostream& os, HTTPRequest& obj);
 
 #endif  // HTTPREQUEST_HPP_

--- a/HTTPRequest.hpp
+++ b/HTTPRequest.hpp
@@ -3,6 +3,7 @@
 
 #include <map>
 #include <string>
+#include <vector>
 
 class HTTPRequest {
  public:
@@ -12,19 +13,27 @@ class HTTPRequest {
   HTTPRequest& operator=(const HTTPRequest& obj);
   HTTPRequest(std::string& input);
 
-  typedef enum { OPTIONS, GET, HEAD, POST, PUT, DELETE, TRACE, CONNECT } method;
-
   typedef enum {
-    HTTP1_1,
-  } version;
+    UNKNOWN,
+    OPTIONS,
+    GET,
+    HEAD,
+    POST,
+    PUT,
+    DELETE,
+    TRACE,
+    CONNECT
+  } method;
 
  private:
   std::map<std::string, std::string> header_;
   std::string body_;
   method request_method_;
-  // std::string URI_;
-  // version protocol_version_;
-  method parseMethodToken(std::string token);
+  std::string URI_;
+  std::string protocol_version_;
+  method parseMethodToken(std::string& token);
+  std::vector<std::string> splitLine(
+      std::string line, std::vector<std::string>::value_type::value_type delim);
 };
 
 #endif  // HTTPREQUEST_HPP_

--- a/HTTPRequest.hpp
+++ b/HTTPRequest.hpp
@@ -1,8 +1,8 @@
 #ifndef HTTPREQUEST_HPP_
 #define HTTPREQUEST_HPP_
 
-#include <string>
 #include <map>
+#include <string>
 
 class HTTPRequest {
  public:
@@ -10,10 +10,20 @@ class HTTPRequest {
   ~HTTPRequest();
   HTTPRequest(const HTTPRequest& obj);
   HTTPRequest& operator=(const HTTPRequest& obj);
+  HTTPRequest(std::string& input);
+
+  typedef enum { OPTIONS, GET, HEAD, POST, PUT, DELETE, TRACE, CONNECT } method;
+
+  typedef enum {
+    HTTP1_1,
+  } version;
 
  private:
   std::map<std::string, std::string> header_;
   std::string body_;
+  // method request_method_;
+  // std::string URI_;
+  // version protocol_version_;
 };
 
 #endif  // HTTPREQUEST_HPP_

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ CYAN =	\033[0;36m
 RED =	\033[0;31m
 WHITE =	\033[0;0m
 
-SRC =	main.cpp TcpServer.cpp HTTPResponse.cpp
+SRC =	main.cpp TcpServer.cpp HTTPResponse.cpp HTTPRequest.cpp
 OBJ =	$(SRC:.cpp=.o)
 
 all:	$(NAME)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NAME =	webserv
 CXX =	c++
-CXXFLAGS =	-std=c++98 -Wall -Wextra -Werror -Wconversion
+CXXFLAGS =	-std=c++98 -Wall -Wextra -Werror #-Wconversion
 
 GREEN =	\033[0;32m
 CYAN =	\033[0;36m

--- a/TcpServer.cpp
+++ b/TcpServer.cpp
@@ -85,10 +85,8 @@ void TcpServer::startListen() {
     if (bytesReceived < 0) {
       exitWithError("Failed to read bytes from client socket connection");
     }
-
-    std::ostringstream ss;
-    ss << "------ Received Request from client ------\n\n";
-    log(ss.str());
+    log("------ Received Request from client ------\n\n");
+    log(buffer);
 
     sendResponse();
 
@@ -124,6 +122,7 @@ void TcpServer::sendResponse() {
 
   if (bytesSent == static_cast<ssize_t>(serverMessage_.size())) {
     log("------ Server Response sent to client ------\n\n");
+    log(serverMessage_);
   } else {
     log("Error sending response to client");
   }

--- a/TcpServer.cpp
+++ b/TcpServer.cpp
@@ -2,6 +2,7 @@
 
 #include <fstream>
 
+#include "HTTPRequest.hpp"
 #include "HTTPResponse.hpp"
 
 const int BUFFER_SIZE = 30720;
@@ -87,6 +88,8 @@ void TcpServer::startListen() {
     }
     log("------ Received Request from client ------\n\n");
     log(buffer);
+    std::string stringyfied_buff(buffer);
+    HTTPRequest req(stringyfied_buff);
 
     sendResponse();
 
@@ -122,7 +125,7 @@ void TcpServer::sendResponse() {
 
   if (bytesSent == static_cast<ssize_t>(serverMessage_.size())) {
     log("------ Server Response sent to client ------\n\n");
-    log(serverMessage_);
+    log(this->serverMessage_);
   } else {
     log("Error sending response to client");
   }

--- a/TcpServer.cpp
+++ b/TcpServer.cpp
@@ -78,7 +78,6 @@ void TcpServer::startListen() {
   ssize_t bytesReceived = 0;
 
   while (true) {
-    log("====== Waiting for a new connection ======\n\n\n");
     acceptConnection(new_socket_);
 
     char buffer[BUFFER_SIZE] = {0};
@@ -86,9 +85,8 @@ void TcpServer::startListen() {
     if (bytesReceived < 0) {
       exitWithError("Failed to read bytes from client socket connection");
     }
-    log("------ Received Request from client ------\n\n");
-    log(buffer);
     std::string stringyfied_buff(buffer);
+    std::cout << "stringyfied_buff: " << stringyfied_buff << std::endl;
     HTTPRequest req(stringyfied_buff);
 
     sendResponse();
@@ -125,7 +123,6 @@ void TcpServer::sendResponse() {
 
   if (bytesSent == static_cast<ssize_t>(serverMessage_.size())) {
     log("------ Server Response sent to client ------\n\n");
-    log(this->serverMessage_);
   } else {
     log("Error sending response to client");
   }

--- a/TcpServer.cpp
+++ b/TcpServer.cpp
@@ -86,8 +86,8 @@ void TcpServer::startListen() {
       exitWithError("Failed to read bytes from client socket connection");
     }
     std::string stringyfied_buff(buffer);
-    std::cout << "stringyfied_buff: " << stringyfied_buff << std::endl;
     HTTPRequest req(stringyfied_buff);
+    std::cout << req << std::endl;
 
     sendResponse();
 


### PR DESCRIPTION
As the title suggests:

- implemented HTTPRequest class
- in TCPServer construct a std::string from the incoming request char buffer
- split request in header and body
- parse the request line of the header
- make a map of the additional header fields
- add the body to the obj