### PR TITLE
catch crashing creation of requests with size <= 1

### DIFF
--- a/src/HTTPRequest.cpp
+++ b/src/HTTPRequest.cpp
@@ -19,6 +19,9 @@ HTTPRequest& HTTPRequest::operator=(const HTTPRequest& obj) {
 }
 
 HTTPRequest::HTTPRequest(std::string& input) {
+  if (input.size() <= 1) {
+    throw std::runtime_error("Error: tried to create request with size <= 1");
+  }
   std::size_t header_end = input.find("\r\n\r\n");
   std::string header(input.begin(), input.begin() + header_end);
   std::string body(input.begin() + header_end + 4, input.end());

--- a/src/TcpServer.cpp
+++ b/src/TcpServer.cpp
@@ -92,11 +92,13 @@ void TcpServer::startListen() {
       exitWithError("Failed to read bytes from client socket connection");
     }
     std::string stringyfied_buff(buffer);
-    HTTPRequest req(stringyfied_buff);
-    std::cout << req << std::endl;
-
-    this->sendResponse(req);
-
+    try {
+      HTTPRequest req(stringyfied_buff);
+      std::cout << req << std::endl;
+      this->sendResponse(req);
+    } catch (std::exception& e) {
+      std::cout << e.what() << std::endl;
+    }
     close(this->new_socket_);
   }
 }


### PR DESCRIPTION
this fix catches the crashes when trying to create a HTTP Request from a string of size <= 1.
What I don't get and couldn't fix rn was the root cause of the constructor being called with a string that small that doesn't seem to be a http request - this might be caused by reading very small amounts of data from the socketfd buffer