### PR TITLE
Add class settings values

### DIFF
--- a/config/default.conf
+++ b/config/default.conf
@@ -1,7 +1,13 @@
 http {
-  port 4444;
   server {
-    server_name testserver;
-    port        4444;
+    server_name             0.0.0.0;
+    port                    4444;
+    404                     ./data/404.html;
+    client_max_body_size    100000;
+    route {
+      root                  ./www;
+      auto-index            true;
+      allow-method          GET;
+    }
   }
 }

--- a/config/default.conf
+++ b/config/default.conf
@@ -1,3 +1,7 @@
 http {
   port 4444;
+  server {
+    server_name testserver;
+    port        4444;
+  }
 }

--- a/src/TcpServer.cpp
+++ b/src/TcpServer.cpp
@@ -31,6 +31,24 @@ TcpServer::TcpServer(const std::string& ip_addr, int port)
   }
 }
 
+TcpServer::TcpServer(const SettingsParser& settings)
+    : ip_addr_(settings.parsed_settings_.server_settings_.begin()->getName()),
+      port_(settings.parsed_settings_.server_settings_.begin()->getPort()),
+      listen_(),
+      numfds_(1),
+      socketAddress_(),
+      socketAddress_len_(sizeof(socketAddress_)) {
+  std::cout << "Port: " << settings.parsed_settings_.server_settings_.begin()->getPort() << std::endl;
+  std::cout << "Sever name: " << settings.parsed_settings_.server_settings_.begin()->getName() << std::endl;
+  socketAddress_.sin_family = AF_INET;
+  socketAddress_.sin_port = htons(port_);
+  socketAddress_.sin_addr.s_addr = INADDR_ANY;
+  if (startServer() != 0) {
+    std::cout << "Error: failed to start server with PORT: "
+              << ntohs(socketAddress_.sin_port) << std::endl;
+  }
+}
+
 TcpServer::~TcpServer() {
   close(this->listen_);
   exit(EXIT_SUCCESS);

--- a/src/TcpServer.cpp
+++ b/src/TcpServer.cpp
@@ -32,14 +32,12 @@ TcpServer::TcpServer(const std::string& ip_addr, int port)
 }
 
 TcpServer::TcpServer(const SettingsParser& settings)
-    : ip_addr_(settings.parsed_settings_.server_settings_.begin()->getName()),
-      port_(settings.parsed_settings_.server_settings_.begin()->getPort()),
+    : ip_addr_(settings.global.servers[0].getName()),
+      port_(settings.global.servers[0].getPort()),
       listen_(),
       numfds_(1),
       socketAddress_(),
       socketAddress_len_(sizeof(socketAddress_)) {
-  std::cout << "Port: " << settings.parsed_settings_.server_settings_.begin()->getPort() << std::endl;
-  std::cout << "Sever name: " << settings.parsed_settings_.server_settings_.begin()->getName() << std::endl;
   socketAddress_.sin_family = AF_INET;
   socketAddress_.sin_port = htons(port_);
   socketAddress_.sin_addr.s_addr = INADDR_ANY;

--- a/src/TcpServer.hpp
+++ b/src/TcpServer.hpp
@@ -25,8 +25,8 @@
 #include <string>
 #include <utility>
 
-#include "HTTPRequest.hpp"
 #include "./parser/SettingsParser.hpp"
+#include "HTTPRequest.hpp"
 #include "Socket.hpp"
 
 class TcpServer {

--- a/src/TcpServer.hpp
+++ b/src/TcpServer.hpp
@@ -26,11 +26,13 @@
 #include <utility>
 
 #include "HTTPRequest.hpp"
+#include "./parser/SettingsParser.hpp"
 #include "Socket.hpp"
 
 class TcpServer {
  public:
   TcpServer(const std::string& ip_addr, int port);
+  TcpServer(const SettingsParser& settings);
   ~TcpServer();
   TcpServer(const TcpServer& obj);
   TcpServer& operator=(const TcpServer& obj);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,14 +12,6 @@ int main() {
   signal(SIGINT, handleSIGINT);
   std::string conf_path("./config/default.conf");
   SettingsParser settings(conf_path);
-  // this is just an example for now - as soon as we know which settings to
-  // parse i'd suggest to switch from settings maps to proper classes with
-  // member values
- // TcpServer server = TcpServer(
- //     "0.0.0.0",
- //     std::strtod(
- //         settings.parsed_settings_.settings_.find("port")->second.c_str(),
- //         NULL));
   TcpServer server = TcpServer(settings);
   server.run();
   return 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,19 +15,12 @@ int main() {
   // this is just an example for now - as soon as we know which settings to
   // parse i'd suggest to switch from settings maps to proper classes with
   // member values
-  TcpServer server = TcpServer(
-      "0.0.0.0",
-      std::strtod(
-          settings.parsed_settings_.settings_.find("port")->second.c_str(),
-          NULL));
+ // TcpServer server = TcpServer(
+ //     "0.0.0.0",
+ //     std::strtod(
+ //         settings.parsed_settings_.settings_.find("port")->second.c_str(),
+ //         NULL));
+  TcpServer server = TcpServer(settings);
   server.run();
   return 0;
 }
-/*
- * TcpServer("0.0.0.0", settings);
- *
- * inside TcpServer:
- *
- * for server in settings.servers
- *  listen to server.port
- */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,3 +23,11 @@ int main() {
   server.run();
   return 0;
 }
+/*
+ * TcpServer("0.0.0.0", settings);
+ *
+ * inside TcpServer:
+ *
+ * for server in settings.servers
+ *  listen to server.port
+ */

--- a/src/parser/ASettings.hpp
+++ b/src/parser/ASettings.hpp
@@ -4,11 +4,16 @@
 #include <map>
 #include <string>
 
+#include "SettingsParser.hpp"
+
 class ASettings {
  public:
   ASettings(){};
   virtual ~ASettings(){};
   std::map<std::string, std::string> settings_;
+
+ protected:
+  virtual bool setValue(std::string key, std::string value) = 0;
 
  private:
   ASettings(const ASettings& obj);

--- a/src/parser/GlobalSettings.hpp
+++ b/src/parser/GlobalSettings.hpp
@@ -11,15 +11,15 @@ class GlobalSettings : public ASettings {
   GlobalSettings(){};
   virtual ~GlobalSettings(){};
   GlobalSettings(const GlobalSettings& obj)
-      : server_settings_(obj.server_settings_) {
+      : servers(obj.servers) {
     this->settings_ = obj.settings_;
   };
   GlobalSettings& operator=(GlobalSettings obj) {
     this->settings_ = obj.settings_;
-    this->server_settings_ = obj.server_settings_;
+    this->servers = obj.servers;
     return *this;
   }
-  std::vector<ServerSettings> server_settings_;
+  std::vector<ServerSettings> servers;
 
   bool setValue(std::string key, std::string value) {
     (void) key;
@@ -27,7 +27,7 @@ class GlobalSettings : public ASettings {
     return true;
   };
   const std::vector<ServerSettings> getServers() const {
-    return this->server_settings_;
+    return this->servers;
   };
  private:
 };

--- a/src/parser/GlobalSettings.hpp
+++ b/src/parser/GlobalSettings.hpp
@@ -10,8 +10,7 @@ class GlobalSettings : public ASettings {
  public:
   GlobalSettings(){};
   virtual ~GlobalSettings(){};
-  GlobalSettings(const GlobalSettings& obj)
-      : servers(obj.servers) {
+  GlobalSettings(const GlobalSettings& obj) : servers(obj.servers) {
     this->settings_ = obj.settings_;
   };
   GlobalSettings& operator=(GlobalSettings obj) {
@@ -22,13 +21,14 @@ class GlobalSettings : public ASettings {
   std::vector<ServerSettings> servers;
 
   bool setValue(std::string key, std::string value) {
-    (void) key;
-    (void) value;
+    (void)key;
+    (void)value;
     return true;
   };
   const std::vector<ServerSettings> getServers() const {
     return this->servers;
   };
+
  private:
 };
 

--- a/src/parser/GlobalSettings.hpp
+++ b/src/parser/GlobalSettings.hpp
@@ -26,6 +26,9 @@ class GlobalSettings : public ASettings {
     (void) value;
     return true;
   };
+  const std::vector<ServerSettings> getServers() const {
+    return this->server_settings_;
+  };
  private:
 };
 

--- a/src/parser/GlobalSettings.hpp
+++ b/src/parser/GlobalSettings.hpp
@@ -21,6 +21,11 @@ class GlobalSettings : public ASettings {
   }
   std::vector<ServerSettings> server_settings_;
 
+  bool setValue(std::string key, std::string value) {
+    (void) key;
+    (void) value;
+    return true;
+  };
  private:
 };
 

--- a/src/parser/LocationSettings.hpp
+++ b/src/parser/LocationSettings.hpp
@@ -1,6 +1,8 @@
 #ifndef LOCATIONSETTINGS_HPP_
 #define LOCATIONSETTINGS_HPP_
 
+#include <vector>
+
 #include "ASettings.hpp"
 
 class LocationSettings : public ASettings {
@@ -14,6 +16,29 @@ class LocationSettings : public ASettings {
     this->settings_ = obj.settings_;
     return *this;
   };
+  bool setValue(std::string key, std::string value) {
+    if (key == "root") {
+      this->root_ = value;
+    } else if (key == "auto-index") {
+      this->auto_index_ = value == "true" ? true : false;
+    } else if (key == "allow-method") {
+      this->allowed_methods_.push_back(value);
+    } else if (key == "allow-upload") {
+      this->allow_upload_ = value == "true" ? true : false;
+    } else if (key == "upload-directory") {
+      this->upload_dir_ = value;
+    } else {
+      return false;
+    }
+    return true;
+  };
+
+ private:
+  std::vector<std::string> allowed_methods_;
+  std::string root_;
+  bool auto_index_;
+  bool allow_upload_;
+  std::string upload_dir_;
 };
 
 #endif  // LOCATIONSETTINGS_HPP_

--- a/src/parser/LocationSettings.hpp
+++ b/src/parser/LocationSettings.hpp
@@ -33,6 +33,14 @@ class LocationSettings : public ASettings {
     return true;
   };
 
+  std::vector<std::string> getAllowedMethods() const {
+    return this->allowed_methods_;
+  };
+  std::string getRoot() const { return this->root_; };
+  bool getAutoIndex() const { return this->auto_index_; };
+  bool getAllowUpload() const { return this->allow_upload_; };
+  std::string getUploadDir() const { return this->upload_dir_; };
+
  private:
   std::vector<std::string> allowed_methods_;
   std::string root_;

--- a/src/parser/LocationSettings.hpp
+++ b/src/parser/LocationSettings.hpp
@@ -9,11 +9,18 @@ class LocationSettings : public ASettings {
  public:
   LocationSettings(){};
   virtual ~LocationSettings(){};
-  LocationSettings(const LocationSettings& obj) {
-    this->settings_ = obj.settings_;
-  };
+  LocationSettings(const LocationSettings& obj)
+      : allowed_methods_(obj.allowed_methods_),
+        root_(obj.root_),
+        auto_index_(obj.auto_index_),
+        allow_upload_(obj.allow_upload_),
+        upload_dir_(obj.upload_dir_){};
   LocationSettings& operator=(const LocationSettings& obj) {
-    this->settings_ = obj.settings_;
+    this->allowed_methods_ = obj.allowed_methods_;
+    this->root_ = obj.root_;
+    this->auto_index_ = obj.auto_index_;
+    this->allow_upload_ = obj.allow_upload_;
+    this->upload_dir_ = obj.upload_dir_;
     return *this;
   };
   bool setValue(std::string key, std::string value) {

--- a/src/parser/ServerSettings.hpp
+++ b/src/parser/ServerSettings.hpp
@@ -1,10 +1,13 @@
 #ifndef SERVERSETTINGS_HPP_
 #define SERVERSETTINGS_HPP_
 
+#include <map>
+#include <string>
 #include <vector>
 
 #include "ASettings.hpp"
 #include "LocationSettings.hpp"
+#include "SettingsParser.hpp"
 
 class ServerSettings : public ASettings {
  public:
@@ -17,9 +20,30 @@ class ServerSettings : public ASettings {
     this->location_settings_ = obj.location_settings_;
     return *this;
   };
+  bool setValue(std::string key, std::string value) {
+    std::cout << "TRYING --- Key: " << key << " value: " << value << std::endl;
+    if (key == "port") {
+      this->port_ = std::atoi(value.c_str());
+    } else if (key == "server_name") {
+      this->server_name_ = value;
+    } else if (key == "client_max_body_size") {
+      this->max_client_body_size_ = std::atoi(value.c_str());
+    } else if (std::atoi(key.c_str()) >= 200 && std::atoi(key.c_str()) < 512) {
+      this->error_pages_.insert(
+          std::pair<unsigned int, std::string>(std::atoi(key.c_str()), value));
+    } else {
+      return false;
+    }
+    std::cout << "SET --- Key: " << key << " value: " << value << std::endl;
+    return true;
+  };
 
  private:
   std::vector<LocationSettings> location_settings_;
+  unsigned int port_;
+  std::string server_name_;
+  std::map<unsigned int, std::string> error_pages_;
+  unsigned int max_client_body_size_;
 };
 
 #endif  // SERVERSETTINGS_HPP_

--- a/src/parser/ServerSettings.hpp
+++ b/src/parser/ServerSettings.hpp
@@ -14,13 +14,13 @@ class ServerSettings : public ASettings {
   ServerSettings(){};
   virtual ~ServerSettings(){};
   ServerSettings(const ServerSettings& obj)
-      : location_settings_(obj.location_settings_),
+      : locations_(obj.locations_),
         port_(obj.port_),
         server_name_(obj.server_name_),
         error_pages_(obj.error_pages_),
         max_client_body_size_(obj.max_client_body_size_){};
   ServerSettings& operator=(const ServerSettings& obj) {
-    this->location_settings_ = obj.location_settings_;
+    this->locations_ = obj.locations_;
     this->port_ = obj.port_;
     this->server_name_ = obj.server_name_;
     this->error_pages_ = obj.error_pages_;
@@ -47,7 +47,7 @@ class ServerSettings : public ASettings {
   };
 
   std::vector<LocationSettings> getRoutes() const {
-    return this->location_settings_;
+    return this->locations_;
   }
   unsigned int getPort() const { return this->port_; };
   std::string getName() const { return this->server_name_; };
@@ -59,7 +59,7 @@ class ServerSettings : public ASettings {
   };
 
  private:
-  std::vector<LocationSettings> location_settings_;
+  std::vector<LocationSettings> locations_;
   unsigned int port_;
   std::string server_name_;
   std::map<unsigned int, std::string> error_pages_;

--- a/src/parser/ServerSettings.hpp
+++ b/src/parser/ServerSettings.hpp
@@ -12,14 +12,19 @@
 class ServerSettings : public ASettings {
  public:
   ServerSettings(){};
-  virtual ~ServerSettings(){
-    std::cout << "Decon called ServerSettings" << std::endl;
-  };
+  virtual ~ServerSettings(){};
   ServerSettings(const ServerSettings& obj)
-      : location_settings_(obj.location_settings_){};
+      : location_settings_(obj.location_settings_),
+        port_(obj.port_),
+        server_name_(obj.server_name_),
+        error_pages_(obj.error_pages_),
+        max_client_body_size_(obj.max_client_body_size_){};
   ServerSettings& operator=(const ServerSettings& obj) {
-    this->settings_ = obj.settings_;
     this->location_settings_ = obj.location_settings_;
+    this->port_ = obj.port_;
+    this->server_name_ = obj.server_name_;
+    this->error_pages_ = obj.error_pages_;
+    this->max_client_body_size_ = obj.max_client_body_size_;
     return *this;
   };
   bool setValue(std::string key, std::string value) {

--- a/src/parser/ServerSettings.hpp
+++ b/src/parser/ServerSettings.hpp
@@ -12,7 +12,9 @@
 class ServerSettings : public ASettings {
  public:
   ServerSettings(){};
-  virtual ~ServerSettings(){};
+  virtual ~ServerSettings(){
+    std::cout << "Decon called ServerSettings" << std::endl;
+  };
   ServerSettings(const ServerSettings& obj)
       : location_settings_(obj.location_settings_){};
   ServerSettings& operator=(const ServerSettings& obj) {
@@ -21,6 +23,7 @@ class ServerSettings : public ASettings {
     return *this;
   };
   bool setValue(std::string key, std::string value) {
+    value.erase(value.size() - 1);
     std::cout << "TRYING --- Key: " << key << " value: " << value << std::endl;
     if (key == "port") {
       this->port_ = std::atoi(value.c_str());
@@ -36,6 +39,18 @@ class ServerSettings : public ASettings {
     }
     std::cout << "SET --- Key: " << key << " value: " << value << std::endl;
     return true;
+  };
+
+  std::vector<LocationSettings> getRoutes() const {
+    return this->location_settings_;
+  }
+  unsigned int getPort() const { return this->port_; };
+  std::string getName() const { return this->server_name_; };
+  std::map<unsigned int, std::string> getErrorPages() const {
+    return this->error_pages_;
+  };
+  unsigned int getMaxClientBodySize() const {
+    return this->max_client_body_size_;
   };
 
  private:

--- a/src/parser/ServerSettings.hpp
+++ b/src/parser/ServerSettings.hpp
@@ -46,9 +46,7 @@ class ServerSettings : public ASettings {
     return true;
   };
 
-  std::vector<LocationSettings> getRoutes() const {
-    return this->locations_;
-  }
+  std::vector<LocationSettings> getRoutes() const { return this->locations_; }
   unsigned int getPort() const { return this->port_; };
   std::string getName() const { return this->server_name_; };
   std::map<unsigned int, std::string> getErrorPages() const {

--- a/src/parser/SettingsParser.cpp
+++ b/src/parser/SettingsParser.cpp
@@ -98,7 +98,7 @@ LocationSettings SettingsParser::parseRoute(
   LocationSettings res;
   for (; it->second != CLOSE_CBR_TOKEN; ++it) {
     if (it->second == VALUE_TOKEN) {
-     res.setValue((it -1)->first, it->first);
+      res.setValue((it - 1)->first, it->first);
     }
   }
   return res;

--- a/src/parser/SettingsParser.cpp
+++ b/src/parser/SettingsParser.cpp
@@ -85,17 +85,20 @@ ServerSettings SettingsParser::parseServer(
   ServerSettings res;
   for (; it->second != CLOSE_CBR_TOKEN; ++it) {
     if (it->second == VALUE_TOKEN) {
-      res.settings_.insert(
-          std::pair<std::string, std::string>((it - 1)->first, it->first));
-      std::cout << "SERVER ADDED: " << (it - 1)->first << ": " << it->first
-                << std::endl;
+      /*
+       * res.settings_.insert(
+       *     std::pair<std::string, std::string>((it - 1)->first, it->first));
+       * std::cout << "SERVER ADDED: " << (it - 1)->first << ": " << it->first
+       *           << std::endl;
+       */
+      res.setValue((it - 1)->first, it->first);
     } else if (it->second == ROUTE_TOKEN) {
       parseRoute(it);
     }
   }
   return res;
 }
-//
+
 LocationSettings SettingsParser::parseRoute(
     std::vector<std::pair<std::string, token_type> >::iterator& it) {
   LocationSettings res;

--- a/src/parser/SettingsParser.cpp
+++ b/src/parser/SettingsParser.cpp
@@ -58,7 +58,7 @@ SettingsParser::SettingsParser(std::string& config_path) {
        i != tokenized_file.end(); ++i) {
   }
   this->tokens_ = tokenized_file;
-  this->parsed_settings_ = parseHTTP();
+  this->global = parseHTTP();
 }
 
 GlobalSettings SettingsParser::parseHTTP() {
@@ -68,7 +68,7 @@ GlobalSettings SettingsParser::parseHTTP() {
            this->tokens_.begin();
        it != this->tokens_.end(); ++it) {
     if (previous == SERVER_TOKEN && it->second == OPEN_CBR_TOKEN) {
-      res.server_settings_.push_back(this->parseServer(it));
+      res.servers.push_back(this->parseServer(it));
     } else if (it->second == VALUE_TOKEN) {
       res.settings_.insert(
           std::pair<std::string, std::string>((it - 1)->first, it->first));
@@ -85,12 +85,6 @@ ServerSettings SettingsParser::parseServer(
   ServerSettings res;
   for (; it->second != CLOSE_CBR_TOKEN; ++it) {
     if (it->second == VALUE_TOKEN) {
-      /*
-       * res.settings_.insert(
-       *     std::pair<std::string, std::string>((it - 1)->first, it->first));
-       * std::cout << "SERVER ADDED: " << (it - 1)->first << ": " << it->first
-       *           << std::endl;
-       */
       res.setValue((it - 1)->first, it->first);
     } else if (it->second == ROUTE_TOKEN) {
       parseRoute(it);
@@ -104,10 +98,6 @@ LocationSettings SettingsParser::parseRoute(
   LocationSettings res;
   for (; it->second != CLOSE_CBR_TOKEN; ++it) {
     if (it->second == VALUE_TOKEN) {
-     // res.settings_.insert(
-     //     std::pair<std::string, std::string>((it - 1)->first, it->first));
-     // std::cout << "LOCATION ADDED: " << (it - 1)->first << ": " << it->first
-     //           << std::endl;
      res.setValue((it -1)->first, it->first);
     }
   }

--- a/src/parser/SettingsParser.cpp
+++ b/src/parser/SettingsParser.cpp
@@ -104,10 +104,11 @@ LocationSettings SettingsParser::parseRoute(
   LocationSettings res;
   for (; it->second != CLOSE_CBR_TOKEN; ++it) {
     if (it->second == VALUE_TOKEN) {
-      res.settings_.insert(
-          std::pair<std::string, std::string>((it - 1)->first, it->first));
-      std::cout << "LOCATION ADDED: " << (it - 1)->first << ": " << it->first
-                << std::endl;
+     // res.settings_.insert(
+     //     std::pair<std::string, std::string>((it - 1)->first, it->first));
+     // std::cout << "LOCATION ADDED: " << (it - 1)->first << ": " << it->first
+     //           << std::endl;
+     res.setValue((it -1)->first, it->first);
     }
   }
   return res;

--- a/src/parser/SettingsParser.hpp
+++ b/src/parser/SettingsParser.hpp
@@ -17,7 +17,7 @@ class SettingsParser {
   SettingsParser& operator=(const SettingsParser& obj);
   SettingsParser(std::string& config_path);
 
-  GlobalSettings parsed_settings_;
+  GlobalSettings global;
 
   typedef enum {
     UNKNOWN_TOKEN,


### PR DESCRIPTION
instead of the settings objects having maps with the key-value pairs from now on explicitly specified member variables shall be used to better access the settings when needed.

Added a new constructor for the tcp server which takes a settings object as param - for now it only handles 1 virtual server but settings wise it is prepared to handle more