### PR TITLE
use locations, error page from config file

### DIFF
--- a/config/default.conf
+++ b/config/default.conf
@@ -4,7 +4,7 @@ http {
     port                    4444;
     404                     ./data/404.html;
     client_max_body_size    100000;
-    route {
+    location {
       root                  ./www;
       auto-index            true;
       allow-method          GET;

--- a/src/HTTPResponse.hpp
+++ b/src/HTTPResponse.hpp
@@ -7,6 +7,7 @@
 #include <string>
 
 #include "HTTPRequest.hpp"
+#include "./parser/SettingsParser.hpp"
 
 class HTTPResponse {
  public:
@@ -16,7 +17,7 @@ class HTTPResponse {
   HTTPResponse(const HTTPResponse& obj);
   HTTPResponse& operator=(const HTTPResponse& obj);
   HTTPResponse(std::string header, std::string body);
-  HTTPResponse(HTTPRequest& req);
+  HTTPResponse(HTTPRequest& req, SettingsParser& settings);
 
   //// Member Functions
   std::string toString() const;
@@ -26,6 +27,7 @@ class HTTPResponse {
   static std::map<std::string, std::string> getMimeTypes(std::string path);
 
  private:
+  SettingsParser settings_;
   std::string header_;
   std::string body_;
   //// Private Member Functions

--- a/src/HTTPResponse.hpp
+++ b/src/HTTPResponse.hpp
@@ -6,8 +6,8 @@
 #include <fstream>
 #include <string>
 
-#include "HTTPRequest.hpp"
 #include "./parser/SettingsParser.hpp"
+#include "HTTPRequest.hpp"
 
 class HTTPResponse {
  public:

--- a/src/TcpServer.cpp
+++ b/src/TcpServer.cpp
@@ -37,7 +37,15 @@ TcpServer::TcpServer(const SettingsParser& settings)
       listen_(),
       numfds_(1),
       socketAddress_(),
-      socketAddress_len_(sizeof(socketAddress_)) {
+      socketAddress_len_(sizeof(socketAddress_)),
+      settings_(settings) {
+  std::cout << "testing settings deep copy" << std::endl;
+  std::cout << "server 0 route len: "
+            << this->settings_.global.servers[0].getRoutes().size()
+            << std::endl;
+  std::cout << "route1: "
+            << this->settings_.global.servers[0].getRoutes().begin()->getRoot()
+            << std::endl;
   socketAddress_.sin_family = AF_INET;
   socketAddress_.sin_port = htons(port_);
   socketAddress_.sin_addr.s_addr = INADDR_ANY;
@@ -227,7 +235,7 @@ void TcpServer::handleConnection(Socket& socket) {
 
 void TcpServer::sendResponse(HTTPRequest& req, Socket& socket) {
   int bytesSent = 0;
-  HTTPResponse res(req);
+  HTTPResponse res(req, this->settings_);
   std::string res_string = res.toString();
   bytesSent = send(socket.getFd(), res_string.data(), res_string.size(), 0);
   if (bytesSent < 0) {

--- a/src/TcpServer.cpp
+++ b/src/TcpServer.cpp
@@ -39,13 +39,6 @@ TcpServer::TcpServer(const SettingsParser& settings)
       socketAddress_(),
       socketAddress_len_(sizeof(socketAddress_)),
       settings_(settings) {
-  std::cout << "testing settings deep copy" << std::endl;
-  std::cout << "server 0 route len: "
-            << this->settings_.global.servers[0].getRoutes().size()
-            << std::endl;
-  std::cout << "route1: "
-            << this->settings_.global.servers[0].getRoutes().begin()->getRoot()
-            << std::endl;
   socketAddress_.sin_family = AF_INET;
   socketAddress_.sin_port = htons(port_);
   socketAddress_.sin_addr.s_addr = INADDR_ANY;

--- a/src/TcpServer.hpp
+++ b/src/TcpServer.hpp
@@ -48,6 +48,7 @@ class TcpServer {
   std::string serverMessage_;
   pollfd pollfds_[255];
   std::map<int, Socket> sockets_;
+  SettingsParser settings_;
 
   int pollError(pollfd& fd);
   int startServer();

--- a/src/parser/LocationSettings.hpp
+++ b/src/parser/LocationSettings.hpp
@@ -14,7 +14,8 @@ class LocationSettings : public ASettings {
         root_(obj.root_),
         auto_index_(obj.auto_index_),
         allow_upload_(obj.allow_upload_),
-        upload_dir_(obj.upload_dir_){};
+        upload_dir_(obj.upload_dir_){
+  };
   LocationSettings& operator=(const LocationSettings& obj) {
     this->allowed_methods_ = obj.allowed_methods_;
     this->root_ = obj.root_;
@@ -24,6 +25,8 @@ class LocationSettings : public ASettings {
     return *this;
   };
   bool setValue(std::string key, std::string value) {
+    value.erase(value.size() - 1);
+    std::cout << "TRYING --- Key: " << key << " value: " << value << std::endl;
     if (key == "root") {
       this->root_ = value;
     } else if (key == "auto-index") {
@@ -37,6 +40,7 @@ class LocationSettings : public ASettings {
     } else {
       return false;
     }
+    std::cout << "SET --- Key: " << key << " value: " << value << std::endl;
     return true;
   };
 

--- a/src/parser/LocationSettings.hpp
+++ b/src/parser/LocationSettings.hpp
@@ -14,8 +14,7 @@ class LocationSettings : public ASettings {
         root_(obj.root_),
         auto_index_(obj.auto_index_),
         allow_upload_(obj.allow_upload_),
-        upload_dir_(obj.upload_dir_){
-  };
+        upload_dir_(obj.upload_dir_){};
   LocationSettings& operator=(const LocationSettings& obj) {
     this->allowed_methods_ = obj.allowed_methods_;
     this->root_ = obj.root_;

--- a/src/parser/ServerSettings.hpp
+++ b/src/parser/ServerSettings.hpp
@@ -14,13 +14,20 @@ class ServerSettings : public ASettings {
   ServerSettings(){};
   virtual ~ServerSettings(){};
   ServerSettings(const ServerSettings& obj)
-      : locations_(obj.locations_),
-        port_(obj.port_),
+      : port_(obj.port_),
         server_name_(obj.server_name_),
         error_pages_(obj.error_pages_),
-        max_client_body_size_(obj.max_client_body_size_){};
+        max_client_body_size_(obj.max_client_body_size_) {
+    for (std::vector<LocationSettings>::size_type i = 0;
+         i < obj.locations.size(); ++i) {
+      this->locations.push_back(obj.locations[i]);
+    }
+  }
   ServerSettings& operator=(const ServerSettings& obj) {
-    this->locations_ = obj.locations_;
+    for (std::vector<LocationSettings>::size_type i = 0;
+         i < obj.locations.size(); ++i) {
+      this->locations.push_back(obj.locations[i]);
+    }
     this->port_ = obj.port_;
     this->server_name_ = obj.server_name_;
     this->error_pages_ = obj.error_pages_;
@@ -29,7 +36,6 @@ class ServerSettings : public ASettings {
   };
   bool setValue(std::string key, std::string value) {
     value.erase(value.size() - 1);
-    std::cout << "TRYING --- Key: " << key << " value: " << value << std::endl;
     if (key == "port") {
       this->port_ = std::atoi(value.c_str());
     } else if (key == "server_name") {
@@ -42,11 +48,10 @@ class ServerSettings : public ASettings {
     } else {
       return false;
     }
-    std::cout << "SET --- Key: " << key << " value: " << value << std::endl;
     return true;
   };
 
-  std::vector<LocationSettings> getRoutes() const { return this->locations_; }
+  std::vector<LocationSettings> getRoutes() const { return this->locations; }
   unsigned int getPort() const { return this->port_; };
   std::string getName() const { return this->server_name_; };
   std::map<unsigned int, std::string> getErrorPages() const {
@@ -55,9 +60,9 @@ class ServerSettings : public ASettings {
   unsigned int getMaxClientBodySize() const {
     return this->max_client_body_size_;
   };
+  std::vector<LocationSettings> locations;
 
  private:
-  std::vector<LocationSettings> locations_;
   unsigned int port_;
   std::string server_name_;
   std::map<unsigned int, std::string> error_pages_;

--- a/src/parser/SettingsParser.cpp
+++ b/src/parser/SettingsParser.cpp
@@ -9,9 +9,10 @@ SettingsParser::SettingsParser() {}
 SettingsParser::~SettingsParser() {}
 
 SettingsParser::SettingsParser(const SettingsParser& obj)
-    : tokens_(obj.tokens_) {}
+    : global(obj.global), tokens_(obj.tokens_) {}
 
 SettingsParser& SettingsParser::operator=(const SettingsParser& obj) {
+  this->global = obj.global;
   this->tokens_ = obj.tokens_;
   return *this;
 }
@@ -83,12 +84,14 @@ GlobalSettings SettingsParser::parseHTTP() {
 ServerSettings SettingsParser::parseServer(
     std::vector<std::pair<std::string, token_type> >::iterator& it) {
   ServerSettings res;
+  token_type previous = UNKNOWN_TOKEN;
   for (; it->second != CLOSE_CBR_TOKEN; ++it) {
-    if (it->second == VALUE_TOKEN) {
+    if (previous == ROUTE_TOKEN && it->second == OPEN_CBR_TOKEN) {
+      res.locations.push_back(parseRoute(it));
+    } else if (it->second == VALUE_TOKEN) {
       res.setValue((it - 1)->first, it->first);
-    } else if (it->second == ROUTE_TOKEN) {
-      parseRoute(it);
     }
+    previous = it->second;
   }
   return res;
 }


### PR DESCRIPTION
- use the first location of the first server for now as root for the URIs
- use the provided error page on 404 errors
- fixed a lot of little bugs on the way (mainly config parsing, but also content-length on error responses)