### PR TITLE
91 use hostname

### DIFF
--- a/config/test.conf
+++ b/config/test.conf
@@ -1,6 +1,21 @@
 http {
   server {
-    server_name             0.0.0.0;
+    listen                  0.0.0.0;
+    server_name             127.0.0.1;
+    port                    4444;
+    404                     ./data/404.html;
+    client_max_body_size    100000;
+    location {
+      endpoint              /;
+      root                  ./www/laurin;
+      default               index.html;
+      auto-index            true;
+      allow-method          GET;
+    }
+  }
+  server {
+    listen                  0.0.0.0;
+    server_name             localhost;
     port                    4444;
     404                     ./data/404.html;
     client_max_body_size    100000;
@@ -21,7 +36,8 @@ http {
     }
   }
   server {
-    server_name             0.0.0.0;
+    listen                  0.0.0.0;
+    server_name             localhost;
     port                    8888;
     404                     ./data/404.html;
     405                     ./data/405.html;

--- a/src/HTTPRequest.cpp
+++ b/src/HTTPRequest.cpp
@@ -129,6 +129,7 @@ HTTPRequest::HTTPRequest(const HTTPRequest& obj)
       query_param_(obj.query_param_),
       protocol_version_(obj.protocol_version_),
       keepalive_(obj.keepalive_),
+      hostname_(obj.hostname_),
       has_request_error_(obj.has_request_error_),
       request_error_(obj.request_error_),
       server_settings_(obj.server_settings_),
@@ -144,6 +145,7 @@ HTTPRequest& HTTPRequest::operator=(const HTTPRequest& obj) {
   this->query_param_ = obj.query_param_;
   this->protocol_version_ = obj.protocol_version_;
   this->keepalive_ = obj.keepalive_;
+  this->hostname_ = obj.hostname_;
   this->has_request_error_ = obj.has_request_error_;
   this->request_error_ = obj.request_error_;
   this->server_settings_ = obj.server_settings_;
@@ -210,7 +212,11 @@ HTTPRequest::HTTPRequest(std::string& input, int port,
   if (this->header_.find("Connection")->second.compare("keep-alive") == 0) {
     this->keepalive_ = true;
   }
-  this->server_settings_ = settings.getServers()[settings.matchServer(port)];
+  if (this->header_.find("Host") != this->header_.end()) {
+    this->hostname_ = this->header_.find("Host")->second;
+  }
+  this->server_settings_ =
+      settings.getServers()[settings.matchServer(port, this->hostname_)];
   this->location_settings_ =
       this->server_settings_
           .getRoutes()[this->server_settings_.matchLocation(this->getURI())];

--- a/src/HTTPRequest.hpp
+++ b/src/HTTPRequest.hpp
@@ -59,6 +59,7 @@ class HTTPRequest {
   std::string query_param_;
   std::string protocol_version_;
   bool keepalive_;
+  std::string hostname_;
   unsigned int has_request_error_;
   std::string request_error_;
   ServerSettings server_settings_;

--- a/src/HTTPResponse.cpp
+++ b/src/HTTPResponse.cpp
@@ -268,5 +268,5 @@ void HTTPResponse::setResponseLine(const std::string& status_code) {
 
 void HTTPResponse::addToHeader(const std::string& key,
                                const std::string& value) {
-  this->headers_.insert(std::pair<std::string, std::string>(key, value));
+  this->headers_[key] = value;
 }

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -76,6 +76,8 @@ int Server::startServer(std::string ip, int port) {
   this->sockets_[this->numfds_] = serv;
   this->pollfds_[this->numfds_] = new_poll;
   this->numfds_++;
+  this->used_ports_.push_back(port);
+  this->used_names_.push_back(ip);
   return EXIT_SUCCESS;
 }
 
@@ -378,6 +380,14 @@ Server::Server(const Settings& settings) : settings_(settings) {
   memset(this->pollfds_, -1, MAX_PORTS);
   this->numfds_ = 0;
   for (size_t i = 0; i < this->settings_.getServers().size(); ++i) {
+    if (std::find(this->used_ports_.begin(), this->used_ports_.end(),
+                  this->settings_.getServers()[i].getPort()) !=
+            this->used_ports_.end() &&
+        std::find(this->used_names_.begin(), this->used_names_.end(),
+                  this->settings_.getServers()[i].getName()) ==
+            this->used_names_.end()) {
+      continue;
+    }
     if (startServer(this->settings_.getServers()[i].getListen(),
                     this->settings_.getServers()[i].getPort())) {
       std::cout << "Error: failed to start Server with port "

--- a/src/Server.hpp
+++ b/src/Server.hpp
@@ -52,6 +52,8 @@ class Server {
   size_t numfds_;
   pollfd pollfds_[MAX_PORTS];
   std::map<int, Socket> sockets_;
+  std::vector<int> used_ports_;
+  std::vector<std::string> used_names_;
   Settings settings_;
   char* cgi_env_[8];
 

--- a/src/parser/Settings.cpp
+++ b/src/parser/Settings.cpp
@@ -60,14 +60,16 @@ const std::vector<ServerSettings> Settings::getServers() const {
   return this->servers;
 }
 
-unsigned int Settings::matchServer(int port) const {
+unsigned int Settings::matchServer(int port, const std::string& name) const {
   unsigned int res = 0;
   unsigned int i = 0;
   for (std::vector<ServerSettings>::const_iterator it = this->servers.begin();
        it != this->servers.end(); ++it) {
-    if ((int)it->getPort() == port) {
+    if ((int)it->getPort() == port && it->getName() == name) {
       res = i;
       break;
+    } else if ((int)it->getPort() == port) {
+      res = i;
     }
     i++;
   }

--- a/src/parser/Settings.hpp
+++ b/src/parser/Settings.hpp
@@ -30,7 +30,7 @@ class Settings : public ASettings {
                            unsigned int route_idx) const;
   std::string getRouteUploadDir(unsigned int server_idx,
                                 unsigned int route_idx) const;
-  unsigned int matchServer(int port) const;
+  unsigned int matchServer(int port, const std::string& name) const;
   unsigned int matchLocationOfServer(unsigned int server_idx,
                                      std::string endpoint) const;
 


### PR DESCRIPTION
we are now matching the host field of a request with the hostname specified in the config. to avoid impossible double-binding of a port we also check if a port is bound already and skip the socket-creation accordingly