### PR TITLE
add parsing error on nested servers

### DIFF
--- a/config/cgi.conf
+++ b/config/cgi.conf
@@ -1,0 +1,22 @@
+http {
+  server {
+    listen                  0.0.0.0;
+    port                    8080;
+    404                     ./data/404.html;
+    client_max_body_size    100000;
+    location {
+      endpoint              /cgi;
+      root                  ./www/laurin;
+      default               index.html;
+      auto-index            false;
+      allow-method          GET;
+    }
+	location {
+		endpoint			/;
+		root				./www/laurin;
+		default				index.html;
+		auto-index			false;
+		allow-method		GET;
+	}
+  }
+}

--- a/src/parser/Parser.cpp
+++ b/src/parser/Parser.cpp
@@ -100,6 +100,8 @@ ServerSettings Parser::parseServer(
         std::string error("In Server Unknown key: " + (it - 1)->first);
         throw std::runtime_error(error.c_str());
       }
+    } else if (it->second == SERVER_TOKEN) {
+      throw std::runtime_error("Nested server not allowed");
     }
     previous = it->second;
   }
@@ -115,6 +117,8 @@ LocationSettings Parser::parseRoute(
         std::string error("In Location Unknown key: " + (it - 1)->first);
         throw std::runtime_error(error.c_str());
       }
+    } else if (it->second == SERVER_TOKEN || it->second == ROUTE_TOKEN) {
+      throw std::runtime_error("Nested location not allowed");
     }
   }
   return res;


### PR DESCRIPTION
Parser now prevents configs from having nested servers and locations